### PR TITLE
Evaluation: fix numpy singleton dim error

### DIFF
--- a/cremi/evaluation/voi.py
+++ b/cremi/evaluation/voi.py
@@ -121,12 +121,12 @@ def vi_tables(x, y=None, ignore_x=[0], ignore_y=[0]):
 
     # Calculate log conditional probabilities and entropies
     lpygx = np.zeros(np.shape(px))
-    lpygx[nzx] = xlogx(divide_rows(nzpxy, nzpx)).sum(axis=1) 
+    lpygx[nzx] = xlogx(divide_rows(nzpxy, nzpx)).sum(axis=1).ravel()
                         # \sum_x{p_{y|x} \log{p_{y|x}}}
     hygx = -(px*lpygx) # \sum_x{p_x H(Y|X=x)} = H(Y|X)
 
     lpxgy = np.zeros(np.shape(py))
-    lpxgy[nzy] = xlogx(divide_columns(nzpxy, nzpy)).sum(axis=0)
+    lpxgy[nzy] = xlogx(divide_columns(nzpxy, nzpy)).sum(axis=0).ravel()
     hxgy = -(py*lpxgy)
 
     return [pxy] + list(map(np.asarray, [px, py, hxgy, hygx, lpygx, lpxgy]))


### PR DESCRIPTION
Fixes the following exception when running something nearly identical to `example_evaluation.py`:

```
Traceback (most recent call last):
  File "example_evaluation.py", line 11, in <module>
    (voi_split, voi_merge) = neuron_ids_evaluation.voi(test.read_neuron_ids())
  File "/home/championa/.virtualenvs/tf11/local/lib/python2.7/site-packages/cremi/evaluation/NeuronIds.py", line 54, in voi
    return voi(np.array(segmentation.data), self.gt, ignore_groundtruth = [0])
  File "/home/championa/.virtualenvs/tf11/local/lib/python2.7/site-packages/cremi/evaluation/voi.py", line 41, in voi
    (hyxg, hxgy) = split_vi(reconstruction, groundtruth, ignore_reconstruction, ignore_groundtruth)
  File "/home/championa/.virtualenvs/tf11/local/lib/python2.7/site-packages/cremi/evaluation/voi.py", line 76, in split_vi
    _, _, _ , hxgy, hygx, _, _ = vi_tables(x, y, ignore_x, ignore_y)
  File "/home/championa/.virtualenvs/tf11/local/lib/python2.7/site-packages/cremi/evaluation/voi.py", line 124, in vi_tables
    lpygx[nzx] = xlogx(divide_rows(nzpxy, nzpx)).sum(axis=1) 
ValueError: shape mismatch: value array of shape (1978,1) could not be broadcast to indexing result of shape (1978,)
```

This is essentially a cherry-pick of janelia-flyem/gala@934f81176641921f47d2243f5cbf5c02b6fab7c8.