### PR TITLE
fix deprecated np.bool

### DIFF
--- a/cremi/evaluation/voi.py
+++ b/cremi/evaluation/voi.py
@@ -158,7 +158,7 @@ def contingency_table(seg, gt, ignore_seg=[0], ignore_gt=[0], norm=True):
     """
     segr = seg.ravel() 
     gtr = gt.ravel()
-    ignored = np.zeros(segr.shape, np.bool)
+    ignored = np.zeros(segr.shape, bool)
     data = np.ones(len(gtr))
     for i in ignore_seg:
         ignored[segr == i] = True


### PR DESCRIPTION
The error is :

```
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
```